### PR TITLE
feat: Add self-describing fromat and deprecation message

### DIFF
--- a/spec/0001-profile.md
+++ b/spec/0001-profile.md
@@ -37,11 +37,13 @@ The `Name` field is a string that uniquely identifies the profile. It is used to
 
 ## `Deprecation`
 
-The optional `Deprecation` map marks a profile as outdated and names its successor, enabling the rolling-migration path described in the [Profile Change and Migration Guidance ADR](../adr/overall/0013-profile-change-migration-guidance.md). When present, the Crypto Broker attaches a deprecation warning to every response produced with this profile, so applications are informed in-band and can migrate before the profile is removed. The profile remains fully functional until it is removed.
+The optional `Deprecation` map marks a profile as outdated and names its successor, enabling the rolling-migration path described in the [Profile Change and Migration Guidance ADR](../adr/overall/0013-profile-change-migration-guidance.md).
+When present, the Crypto Broker attaches a deprecation warning to every response produced with this profile, so applications are informed in-band and can migrate before the profile is removed.
+The profile remains fully functional until it is removed.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `SupersededBy` | String | *(Optional)* Name of the successor profile applications should migrate to. |
+| `ReplacedBy` | String | *(Optional)* Name of the successor profile applications should migrate to. |
 | `DeprecatedSince` | String | *(Optional)* Date the profile was deprecated (e.g., `2026-01-01`). |
 | `RemoveAfter` | String | *(Optional)* Sunset date after which the profile is removed (e.g., `2026-12-31`). |
 | `Reason` | String | *(Optional)* Human-readable explanation of why the profile is deprecated. |
@@ -51,13 +53,13 @@ Example:
 ```yaml
 - Name: Default-2025
   Deprecation:
-    SupersededBy: Default-2026
+    ReplacedBy: Default-2026
     DeprecatedSince: 2026-01-01
     RemoveAfter: 2026-12-31
     Reason: "SHA3-512 replaced per crypto policy update"
 ```
 
-> Note: `SupersededBy` is a redirection pointer and therefore a downgrade vector. It must only ever point to an equal-or-stronger profile, and changes to it must be covered by change-management and audit controls, so that an attacker who can edit `Profiles.yaml` cannot steer clients toward a weaker profile.
+> Note: `ReplacedBy` is a redirection pointer and therefore a downgrade vector. It should only ever point to an equal-or-stronger profile, and changes to it should be covered by change-management and audit controls, so that an attacker who can edit `Profiles.yaml` cannot steer clients toward a weaker profile.
 
 ## API: `HashData`
 

--- a/spec/0001-profile.md
+++ b/spec/0001-profile.md
@@ -15,6 +15,7 @@ The first part of this document describes the structure of a profile. The second
 | `Name` | String | Name of the profile (e.g., `Default`, `PCI-DSS`). Must be unique. |
 | `Settings` | Map | Global cryptographic settings, e.g. which cryptographic library to use or which key storage to use. |
 | `API` | Map | Optional API-specific configuration sections. |
+| `Deprecation` | Map | *(Optional)* Marks the profile as deprecated and points to its successor for a rolling migration. See [`Deprecation`](#deprecation). |
 
 #### Notes
 
@@ -33,6 +34,30 @@ The `Name` field is a string that uniquely identifies the profile. It is used to
 | --- | --- | --- |
 | `CryptoLibrary` | String | The underlying cryptographic library to use (e.g., `openssl` or `native`). |
 | `KMS` | String | *(Optional)* Key storage backend used to manage key material for this profile (e.g., `openbao`). If unset, the profile is caller-managed and the broker keeps no key material; if set, the profile is broker-managed and keys are referenced by identifier. See the [Key Storage Backend ADR](../adr/overall/0011-key-storage-backend.md). |
+
+## `Deprecation`
+
+The optional `Deprecation` map marks a profile as outdated and names its successor, enabling the rolling-migration path described in the [Profile Change and Migration Guidance ADR](../adr/overall/0013-profile-change-migration-guidance.md). When present, the Crypto Broker attaches a deprecation warning to every response produced with this profile, so applications are informed in-band and can migrate before the profile is removed. The profile remains fully functional until it is removed.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `SupersededBy` | String | *(Optional)* Name of the successor profile applications should migrate to. |
+| `DeprecatedSince` | String | *(Optional)* Date the profile was deprecated (e.g., `2026-01-01`). |
+| `RemoveAfter` | String | *(Optional)* Sunset date after which the profile is removed (e.g., `2026-12-31`). |
+| `Reason` | String | *(Optional)* Human-readable explanation of why the profile is deprecated. |
+
+Example:
+
+```yaml
+- Name: Default-2025
+  Deprecation:
+    SupersededBy: Default-2026
+    DeprecatedSince: 2026-01-01
+    RemoveAfter: 2026-12-31
+    Reason: "SHA3-512 replaced per crypto policy update"
+```
+
+> Note: `SupersededBy` is a redirection pointer and therefore a downgrade vector. It must only ever point to an equal-or-stronger profile, and changes to it must be covered by change-management and audit controls, so that an attacker who can edit `Profiles.yaml` cannot steer clients toward a weaker profile.
 
 ## API: `HashData`
 

--- a/spec/0002-library.md
+++ b/spec/0002-library.md
@@ -70,6 +70,7 @@ The `HashData` API returns a response body `HashDataResponse`, from which the fo
 | `hashValueHex` | String | Hash value of the provided input bytes as a hexadecimal string. Set when `outputFormat` is `HEX`. |
 | `hashValueRaw` | Bytes | Hash value of the provided input bytes as raw bytes. Set when `outputFormat` is `RAW`. |
 | `hashAlgorithm` | String | Hash algorithm used to compute the hash value (e.g. `SHA-256` or `SHA3-256`). |
+| `descriptor` | Map | Self-describing descriptor of how the hash was produced (see [`descriptor` message](#descriptor-message)). Should be persisted alongside the hash value. |
 | `metadata` | Map | Metadata about the Crypto Broker request/response. |
 
 #### `SignCertificate`
@@ -99,6 +100,7 @@ The `SignCertificate` API returns a response body `SignCertificateResponse`, fro
 | --- | --- | --- |
 | `pem` | String | PEM-encoded signed certificate. Set when `outputFormat` is `PEM`. |
 | `der` | Bytes | DER-encoded signed certificate. Set when `outputFormat` is `DER`. |
+| `descriptor` | Map | Self-describing descriptor of how the certificate was signed (see [`descriptor` message](#descriptor-message)). Should be persisted alongside the certificate. |
 | `metadata` | Map | Metadata about the Crypto Broker request/response. |
 
 All other values like validity, signature algorithm etc. can be extracted from the certificate itself.
@@ -198,6 +200,7 @@ All other languages need to include the `health.proto` file in the protobuf comp
 | --- | --- | --- |
 | `id` | String | ID of the request, given as a UUID v4 in String format. |
 | `traceContext` | Map | *(Optional)* Trace context for manual propagation of distributed tracing information. |
+| `deprecation` | Map | *(Optional)* Deprecation warning (see [`deprecation`](#deprecation)). Set on every response produced with a deprecated profile. |
 
 ### `traceContext`
 
@@ -208,6 +211,32 @@ All other languages need to include the `health.proto` file in the protobuf comp
 | `traceFlags` | String | Trace flags (e.g. sampling decision). |
 | `traceState` | String | Vendor-specific trace state. |
 | `correlationId` | String | Correlation identifier for the request. |
+
+### `deprecation`
+
+Deprecation warning attached to every response produced with a deprecated profile, enabling the rolling-migration path described in the [Profile Change and Migration Guidance ADR](../adr/overall/0013-profile-change-migration-guidance.md). The values mirror the profile's [`Deprecation`](0001-profile.md#deprecation) metadata.
+
+| Variable | Type | Description |
+| --- | --- | --- |
+| `profile` | String | Name of the deprecated profile the response was produced with. |
+| `supersededBy` | String | *(Optional)* Name of the successor profile the application should migrate to. |
+| `deprecatedSince` | String | *(Optional)* Date the profile was deprecated. |
+| `removeAfter` | String | *(Optional)* Sunset date after which the profile is removed. |
+| `reason` | String | *(Optional)* Human-readable explanation of why the profile is deprecated. |
+
+---
+
+## `descriptor` message
+
+Self-describing record of how a stored cryptographic artifact was produced, returned by the record-producing APIs (`HashData`, `SignCertificate`, `EncryptData`).
+Applications **should persist this descriptor verbatim alongside the value**, so that the record stays verifiable and migratable even after the underlying profile changes, and without access to `Profiles.yaml`.
+See the [Profile Change and Migration Guidance ADR](../adr/overall/0013-profile-change-migration-guidance.md) for the rationale.
+
+| Variable | Type | Description |
+| --- | --- | --- |
+| `profile` | String | Name of the profile that produced the artifact. |
+| `operation` | String | The API that produced the artifact (e.g. `HashData`, `SignCertificate`, `EncryptData`). |
+| `algorithm` | String | The concrete algorithm actually used (e.g. `sha3-512`, `aes-gcm`). |
 
 ---
 
@@ -244,6 +273,7 @@ In fully KMS-managed flows the broker stores these itself, so only the `keyId` i
 | `nonce` | Bytes | *(Optional)* The nonce actually used for encryption. |
 | `aad` | Bytes | *(Optional)* The additional authenticated data bound to the ciphertext. |
 | `tag` | Bytes | *(Optional)* The authentication tag produced by the authenticated encryption algorithm. |
+| `descriptor` | Map | Self-describing descriptor of how the ciphertext was produced (see [`descriptor` message](#descriptor-message)). Should be persisted alongside the ciphertext. |
 
 ## `decryptMetadata` message
 

--- a/spec/0002-library.md
+++ b/spec/0002-library.md
@@ -219,7 +219,7 @@ Deprecation warning attached to every response produced with a deprecated profil
 | Variable | Type | Description |
 | --- | --- | --- |
 | `profile` | String | Name of the deprecated profile the response was produced with. |
-| `supersededBy` | String | *(Optional)* Name of the successor profile the application should migrate to. |
+| `replacedBy` | String | *(Optional)* Name of the successor profile the application should migrate to. |
 | `deprecatedSince` | String | *(Optional)* Date the profile was deprecated. |
 | `removeAfter` | String | *(Optional)* Sunset date after which the profile is removed. |
 | `reason` | String | *(Optional)* Human-readable explanation of why the profile is deprecated. |

--- a/spec/0003-server.md
+++ b/spec/0003-server.md
@@ -66,7 +66,7 @@ Every production cryptographic request is processed through the following stages
 1. **Resolve profile** — the profile named in the request is retrieved from the set of profiles loaded at startup. An unknown profile name results in an error.
 1. **Validate input** — the request payload is validated against the rules of the resolved profile. This includes parsing cryptographic material (CSR, CA certificate, private key) and checking it against profile constraints.
 1. **Execute** — the approved operation is delegated to the cryptographic backend, which performs the hashing or certificate signing using the algorithm and parameters selected by the profile.
-1. **Respond** — the result is packaged into the corresponding response message together with request metadata and returned to the client. On failure, a verbose error is returned instead.
+1. **Respond** — the result is packaged into the corresponding response message together with request metadata and returned to the client. Record-producing operations additionally return a self-describing descriptor (profile, operation and the concrete algorithm used) so the caller can persist it alongside the value (see [Self-describing responses](#self-describing-responses)). When the resolved profile is deprecated, a deprecation warning is attached to the response. On failure, a verbose error is returned instead.
 
 The server does not perform cryptographic operations that are not authorized by a profile, and it never selects algorithms or parameters that are not permitted by the resolved profile.
 
@@ -80,6 +80,14 @@ Profiles are the central policy mechanism of the server. Each profile defines wh
 - Loading fails fast: if the file cannot be read, parsed, or if any profile is invalid or references unsupported values, the server does not start.
 - At request time, a profile is retrieved by its name. Requests that reference an unknown profile are rejected.
 - Profile names are validated and bounded in length.
+
+### Profile deprecation and migration
+
+A profile may carry optional deprecation metadata (see the [Profile Specification](https://github.com/open-crypto-broker/crypto-broker-documentation/blob/main/spec/0001-profile.md) and the [Profile Change and Migration Guidance ADR](https://github.com/open-crypto-broker/crypto-broker-documentation/blob/main/adr/overall/0013-profile-change-migration-guidance.md)). When a request resolves to a deprecated profile, the server still performs the operation and additionally attaches a deprecation warning to the response, naming the successor profile and the sunset date. This enables a rolling migration in which applications are informed in-band and migrate before the profile is removed. The successor referenced by `SupersededBy` must only ever point to an equal-or-stronger profile; because the server cannot enforce this technically, it must be governed by change-management and audit controls.
+
+### Self-describing responses
+
+Record-producing operations (`HashData`, `SignCertificate`, `EncryptData`) return a self-describing descriptor alongside the result, capturing the profile, the operation and the concrete algorithm actually used. Applications are expected to persist this descriptor with the stored artifact so that records remain verifiable and migratable across later profile changes. Editing the algorithms of an existing profile in place is a supported but breaking action: applications that compare freshly computed values against previously stored ones can silently break, so such changes should instead be performed as a rolling migration via a new profile and deprecation metadata.
 
 ---
 
@@ -146,6 +154,7 @@ The server is designed to enforce cryptographic policy and to minimize exposure:
 - **Resource limits** — request and response message sizes and the number of concurrent streams are bounded to reduce the impact of abusive or malformed traffic.
 - **Reduced production surface** — the development service (`CryptoGrpcDev`) is only registered in development environments and is disabled in production.
 - **Sensitive material handling** — sensitive key material is zeroized in memory once it is no longer needed.
+- **No silent downgrade** — a deprecated profile's `SupersededBy` pointer is a downgrade vector and must only reference an equal-or-stronger profile, under change-management and audit controls.
 
 ### FIPS 140 mode
 

--- a/spec/0003-server.md
+++ b/spec/0003-server.md
@@ -90,7 +90,7 @@ The profile structure is defined in the [Crypto Broker Profile Specification](ht
 A profile may carry optional deprecation metadata (see the [Profile Specification](https://github.com/open-crypto-broker/crypto-broker-documentation/blob/main/spec/0001-profile.md) and the [Profile Change and Migration Guidance ADR](https://github.com/open-crypto-broker/crypto-broker-documentation/blob/main/adr/overall/0013-profile-change-migration-guidance.md)).
 When a request resolves to a deprecated profile, the server still performs the operation and additionally attaches a deprecation warning to the response, naming the successor profile and the sunset date.
 This enables a rolling migration in which applications are informed in-band and migrate before the profile is removed.
-The successor referenced by `SupersededBy` must only ever point to an equal-or-stronger profile; because the server cannot enforce this technically, it must be governed by change-management and audit controls.
+It is recommended that the successor referenced by `replacedBy` should point to an equal-or-stronger profile; because the server cannot enforce this technically, it must be governed by change-management and audit controls.
 
 ### Self-describing responses
 
@@ -163,7 +163,7 @@ The server is designed to enforce cryptographic policy and to minimize exposure:
 - **Resource limits** — request and response message sizes and the number of concurrent streams are bounded to reduce the impact of abusive or malformed traffic.
 - **Reduced production surface** — the development service (`CryptoGrpcDev`) is only registered in development environments and is disabled in production.
 - **Sensitive material handling** — sensitive key material is zeroized in memory once it is no longer needed.
-- **No silent downgrade** — a deprecated profile's `SupersededBy` pointer is a downgrade vector and must only reference an equal-or-stronger profile, under change-management and audit controls.
+- **No silent downgrade** — a deprecated profile's `replacedBy` pointer is a downgrade vector and must only reference an equal-or-stronger profile, under change-management and audit controls.
 
 ### FIPS 140 mode
 

--- a/spec/0003-server.md
+++ b/spec/0003-server.md
@@ -66,7 +66,9 @@ Every production cryptographic request is processed through the following stages
 1. **Resolve profile** — the profile named in the request is retrieved from the set of profiles loaded at startup. An unknown profile name results in an error.
 1. **Validate input** — the request payload is validated against the rules of the resolved profile. This includes parsing cryptographic material (CSR, CA certificate, private key) and checking it against profile constraints.
 1. **Execute** — the approved operation is delegated to the cryptographic backend, which performs the hashing or certificate signing using the algorithm and parameters selected by the profile.
-1. **Respond** — the result is packaged into the corresponding response message together with request metadata and returned to the client. Record-producing operations additionally return a self-describing descriptor (profile, operation and the concrete algorithm used) so the caller can persist it alongside the value (see [Self-describing responses](#self-describing-responses)). When the resolved profile is deprecated, a deprecation warning is attached to the response. On failure, a verbose error is returned instead.
+1. **Respond** — the result is packaged into the corresponding response message together with request metadata and returned to the client.
+Record-producing operations additionally return a self-describing descriptor (profile, operation and the concrete algorithm used) so the caller can persist it alongside the value (see [Self-describing responses](#self-describing-responses)).
+When the resolved profile is deprecated, a deprecation warning is attached to the response. On failure, a verbose error is returned instead.
 
 The server does not perform cryptographic operations that are not authorized by a profile, and it never selects algorithms or parameters that are not permitted by the resolved profile.
 
@@ -74,7 +76,9 @@ The server does not perform cryptographic operations that are not authorized by 
 
 ## Profiles
 
-Profiles are the central policy mechanism of the server. Each profile defines which cryptographic operations are allowed and under which constraints (algorithms, key-size limits, certificate validity boundaries, key usages, and so on). The profile structure is defined in the [Crypto Broker Profile Specification](https://github.com/open-crypto-broker/crypto-broker-documentation/blob/main/spec/0001-profile.md).
+Profiles are the central policy mechanism of the server.
+Each profile defines which cryptographic operations are allowed and under which constraints (algorithms, key-size limits, certificate validity boundaries, key usages, and so on).
+The profile structure is defined in the [Crypto Broker Profile Specification](https://github.com/open-crypto-broker/crypto-broker-documentation/blob/main/spec/0001-profile.md).
 
 - Profiles are loaded and validated once at startup from a YAML file (`Profiles.yaml`). The directory containing this file is provided via configuration.
 - Loading fails fast: if the file cannot be read, parsed, or if any profile is invalid or references unsupported values, the server does not start.
@@ -83,11 +87,16 @@ Profiles are the central policy mechanism of the server. Each profile defines wh
 
 ### Profile deprecation and migration
 
-A profile may carry optional deprecation metadata (see the [Profile Specification](https://github.com/open-crypto-broker/crypto-broker-documentation/blob/main/spec/0001-profile.md) and the [Profile Change and Migration Guidance ADR](https://github.com/open-crypto-broker/crypto-broker-documentation/blob/main/adr/overall/0013-profile-change-migration-guidance.md)). When a request resolves to a deprecated profile, the server still performs the operation and additionally attaches a deprecation warning to the response, naming the successor profile and the sunset date. This enables a rolling migration in which applications are informed in-band and migrate before the profile is removed. The successor referenced by `SupersededBy` must only ever point to an equal-or-stronger profile; because the server cannot enforce this technically, it must be governed by change-management and audit controls.
+A profile may carry optional deprecation metadata (see the [Profile Specification](https://github.com/open-crypto-broker/crypto-broker-documentation/blob/main/spec/0001-profile.md) and the [Profile Change and Migration Guidance ADR](https://github.com/open-crypto-broker/crypto-broker-documentation/blob/main/adr/overall/0013-profile-change-migration-guidance.md)).
+When a request resolves to a deprecated profile, the server still performs the operation and additionally attaches a deprecation warning to the response, naming the successor profile and the sunset date.
+This enables a rolling migration in which applications are informed in-band and migrate before the profile is removed.
+The successor referenced by `SupersededBy` must only ever point to an equal-or-stronger profile; because the server cannot enforce this technically, it must be governed by change-management and audit controls.
 
 ### Self-describing responses
 
-Record-producing operations (`HashData`, `SignCertificate`, `EncryptData`) return a self-describing descriptor alongside the result, capturing the profile, the operation and the concrete algorithm actually used. Applications are expected to persist this descriptor with the stored artifact so that records remain verifiable and migratable across later profile changes. Editing the algorithms of an existing profile in place is a supported but breaking action: applications that compare freshly computed values against previously stored ones can silently break, so such changes should instead be performed as a rolling migration via a new profile and deprecation metadata.
+Record-producing operations (`HashData`, `SignCertificate`, `EncryptData`) return a self-describing descriptor alongside the result, capturing the profile, the operation and the concrete algorithm actually used.
+Applications are expected to persist this descriptor with the stored artifact so that records remain verifiable and migratable across later profile changes.
+Editing the algorithms of an existing profile in place is a supported but breaking action: applications that compare freshly computed values against previously stored ones can silently break, so such changes should instead be performed as a rolling migration via a new profile and deprecation metadata.
 
 ---
 


### PR DESCRIPTION
## Description
Add specifications for the self-describing format and the deprecation message.
The profile holds the Deprecation entry, the server parses it and in each gRPC response in the Metadata field the deprecation warning is transmitted. This helps applications for a rolling profile migration path.

## Type of change
- [ ] Bug fix
- [x] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [ ] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
