### PR TITLE
fix: Make EncryptMetadata and DecryptMetadata non optional

### DIFF
--- a/spec/0002-library.md
+++ b/spec/0002-library.md
@@ -119,7 +119,7 @@ Encryption parameters are supplied via `encryptMetadata`: the caller always prov
 | `profile` | String | Name of the profile (e.g., `Default`, `PCI-DSS`). |
 | `keySource` | Map | Key material to use, given as a [`KeySource`](#keysource-message). Either a `keyId` (KMS-backed) or `rawKey` (caller-managed). |
 | `plaintext` | Bytes | Arbitrary input to be encrypted. |
-| `encryptMetadata` | Map | *(Optional)* Caller-supplied encryption parameters (see [`encryptMetadata` message](#encryptmetadata-message)), e.g. nonce and AAD. |
+| `encryptMetadata` | Map | Caller-supplied encryption parameters (see [`encryptMetadata` message](#encryptmetadata-message)), e.g. nonce and AAD. |
 | `metadata` | Map | *(Optional)* Metadata about the Crypto Broker request/response. |
 
 ##### `EncryptData` Output
@@ -145,7 +145,7 @@ The caller provides the same `keySource` variant expected by the profile, and su
 | `profile` | String | Name of the profile (e.g., `Default`, `PCI-DSS`). |
 | `keySource` | Map | Key material to use, given as a [`KeySource`](#keysource-message). Either a `keyId` (KMS-backed) or `rawKey` (caller-managed). |
 | `ciphertext` | Bytes | The encrypted data to be decrypted. |
-| `decryptMetadata` | Map | *(Optional)* Caller-supplied decryption parameters (see [`decryptMetadata` message](#decryptmetadata-message)), e.g. nonce, AAD and authentication tag. |
+| `decryptMetadata` | Map | Caller-supplied decryption parameters (see [`decryptMetadata` message](#decryptmetadata-message)), e.g. nonce, AAD and authentication tag. |
 | `metadata` | Map | *(Optional)* Metadata about the Crypto Broker request/response. |
 
 ##### `DecryptData` Output


### PR DESCRIPTION
## Description
EncryptMetadata and DecryptMetadata need to be provided as these provide the nonce field.

## Type of change
- [x] Bug fix
- [ ] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [ ] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
